### PR TITLE
Fix source concentration of reference samples.

### DIFF
--- a/sim/enviroment/area/GaussianPlumeArea.m
+++ b/sim/enviroment/area/GaussianPlumeArea.m
@@ -147,7 +147,7 @@ classdef GaussianPlumeArea<PlumeArea
         
         function obj = computeReferenceSamples(obj)
             % compute samples from the underlying model
-            obj.referenceSamples = ((((2*pi)^3)*obj.detSigma)^0.5)*obj.getSamples(obj.locations);
+            obj.referenceSamples = obj.Q0*obj.getSamples(obj.locations);
         end
     end
 end


### PR DESCRIPTION
`obj.Q0` is currently set to 1, thus the value of the reference samples was a few magnitudes too high.
