### PR TITLE
Reset controllers via TCP.

### DIFF
--- a/tcp-linux/matlab/QRSimTCPServer.m.in
+++ b/tcp-linux/matlab/QRSimTCPServer.m.in
@@ -113,6 +113,8 @@ while (~exit)
                     try
                         %reset
                         qrsim.reset();
+                        velpid.reset();
+                        wppid.reset();
                         % return ack
                         s.sendAck(0);
                     catch e


### PR DESCRIPTION
Otherwise they'll continue to use state information stored from before
the reset and may lead to different simulation results on different
simulation runs (despite same rng seed).
