### PR TITLE
Fix failing TCP server if much data is received

### DIFF
--- a/tcp-linux/java/qrsimsrvcli/QRSimTCPServer.java
+++ b/tcp-linux/java/qrsimsrvcli/QRSimTCPServer.java
@@ -72,6 +72,7 @@ public Message nextCommand() throws Exception
     Message msg = mb.build();
     //System.out.println("got message of type "+ msg.getType());
 
+    is.resetSizeCounter();
     return msg;
   }
 


### PR DESCRIPTION
The Google protocol buffer documentation states that one has to reset
the size counter after each message in case multiple messages will be
read with one CodedInputStream.

cp. https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/CodedInputStream.html#setSizeLimit(int)
